### PR TITLE
Use regular properties when exporting constants to play nicely with Jest

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,21 +3,11 @@ var Integer = module.exports = require('bindings')({
 	module_root: __dirname
 }).Integer;
 
-
-defineStatic('MAX_VALUE', Integer.fromBits(-1, 0x7fffffff));
-defineStatic('MIN_VALUE', Integer.fromBits(0, -0x80000000));
-defineStatic('ZERO', Integer.fromBits(0, 0));
-defineStatic('ONE', Integer.fromBits(1, 0));
-defineStatic('NEG_ONE', Integer.fromBits(-1, -1));
-
-function defineStatic(key, value) {
-	Object.defineProperty(Integer, key, {
-		writable: false,
-		enumerable: true,
-		configurable: false,
-		value: value
-	});
-}
+Integer.MAX_VALUE = Integer.fromBits(-1, 0x7fffffff);
+Integer.MIN_VALUE = Integer.fromBits(0, -0x80000000);
+Integer.ZERO = Integer.fromBits(0, 0);
+Integer.ONE = Integer.fromBits(1, 0);
+Integer.NEG_ONE = Integer.fromBits(-1, -1);
 
 function alias(methodName, aliases) {
 	var method = Integer.prototype[methodName];


### PR DESCRIPTION
I'm trying to use better-sqlite3 with jest. better-sqlite3 depends on this module and apparently there's a problem running it via jest. I already found https://github.com/JoshuaWise/better-sqlite3/issues/45 which gives some insight.

I completely understand not wanting to remove functionality for Jest, and I wouldn't recommend removing Integer. However, with these small changes I was able to get it work. I think it's a good compromise and, while it may not be quite as sound as defining static property, being compatible with the current JS ecosystem is going to help better-sqlite3 be used a lot more.

Sidenote: I love _love_ *love* better-sqlite3. Thank you so much. I was able to remove *so much complexity* in my app by using simple synchronous APIs, and I've never understood why node-sqlite3 is asynchronous because sqlite3 itself is not async. It only ever runs one query at a time. Why in the world would we be using async bindings to it? Your library is exactly what I've been looking for and it's so, so much better.