### PR TITLE
Prebuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,35 @@
 language: node_js
 sudo: false
 node_js:
-- "8"
-- "9"
-- "10"
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-4.9
-    - g++-4.9
-before_install:
-- export CC="gcc-4.9" CXX="g++-4.9"
+- 'node'
+matrix:
+  include:
+    - os: linux
+      env: MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - gcc-4.9
+          - g++-4.9
+    - os: osx
+      osx_image: xcode11
+      compiler: clang
+      env: MATRIX_EVAL="CC=gcc && CXX=g++"
 before_script:
 - npm run install-debug
+before_deploy:
+- npm install
+- npm run prebuild
+- npm run prebuild-electron
+deploy:
+  provider: releases
+  api_key:
+    secure: rwWWvPa2nhfDeDO5hSZr0O92u8/KnEzxzV3qagBmykvcAkw1iyfzio+T1T59B0mbz+ECph8CkZ0/BMEKT9Q5uoH4rr+fAOWUj4yAlC+hA22hJO8Ux/lbGEJmKFHsYzv8K7nFokn0aT0LihS2qhVweHMYpuhBYIjnyeSVbc0r2PgwyA4EUNRuams54B9iNmSogtqs5vSqGGfJA2wW4OBCqZ3bVK2g1EeGArvxQR2JG3e0mrVntXv0EiNJApiXxh3J2QIq7gyiiArpDVjY4GHHgDCgCzCMl9uNckBTjwHaDo18QJShIrTrRz/kbGmoiWlzvfdFSu9rkodliZr0ym/o0ly7If7isGYNhRxSHxdxIhIPjmBFoDKnCUO341MjCHHV1u1S/1fMCN9vDXItKWUG6pcKfCOOGnGldRSopmQJ8wWMZXQkacHvF5hokTuBt2yrTd8Snz4mHtNkVljuP/faU8YLo1U7BgoRY1gZ+RJzcwb+T9mA+499fE9GgiIqjntetJFDlv+RUtV0f3Ec9j5Y6hwyjXMdYqSUBoIkI+UUOUbiSSotcGnz7Je7bfr6DWgRjTy9edqMlOBcL7+ThhcdvOyjzmyMoNlQ6UP4q4DVr+Npdbm6aEC+NrFy88fF8VNXbrfpXuj8GhmVtksgY6rfQ6NeMOFbbu0AMXMkzF5BKjw=
+  file: prebuilds/*
+  file_glob: true
+  skip_cleanup: true
+  on:
+    repo: danielbarela/integer
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: node_js
 sudo: false
-node_js:
-- 'node'
 matrix:
   include:
-    - os: linux
-      env: MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+    # linux builds
+    - name: "Linux - Node 8"
+      os: linux
+      node_js: "8"
+      env: 
+        - CXX="g++-4.9"
+        - CC=gcc-4.9
       addons:
         apt:
           sources:
@@ -13,10 +16,56 @@ matrix:
           packages:
           - gcc-4.9
           - g++-4.9
-    - os: osx
+    - name: "Linux - Node 10"
+      os: linux
+      node_js: "10"
+      env: 
+        - CXX="g++-4.9"
+        - CC=gcc-4.9
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - gcc-4.9
+          - g++-4.9
+    - name: "Linux - Node 12"
+      os: linux
+      node_js: "12"
+      env: 
+        - CXX="g++-4.9"
+        - CC=gcc-4.9
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - gcc-4.9
+          - g++-4.9
+    - name: "OS X - Node 8"
+      os: osx
+      node_js: "8"
       osx_image: xcode11
       compiler: clang
-      env: MATRIX_EVAL="CC=gcc && CXX=g++"
+      env: 
+        - CXX=g++
+        - CC=gcc
+    - name: "OS X - Node 10"
+      os: osx
+      node_js: "10"
+      osx_image: xcode11
+      compiler: clang
+      env: 
+        - CXX=g++
+        - CC=gcc
+    - name: "OS X - Node 12"
+      os: osx
+      node_js: "12"
+      osx_image: xcode11
+      compiler: clang
+      env: 
+        - CXX=g++
+        - CC=gcc
 before_script:
 - npm run install-debug
 before_deploy:

--- a/binding.gyp
+++ b/binding.gyp
@@ -64,15 +64,6 @@
           '-stdlib=libc++',
         ],
       },
-    },
-    {
-      'target_name': 'place_resulting_binary',
-      'type': 'none',
-      'dependencies': ['integer'],
-      'copies': [{
-        'files': ['<(PRODUCT_DIR)/integer.node'],
-        'destination': 'build',
-      }],
-    },
+    }
   ],
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const Integer = module.exports = require('../build/integer.node').Integer;
+const Integer = module.exports = require('bindings')('integer.node').Integer;
 
 const defineStatic = (key, value) => {
 	if (Integer.hasOwnProperty(key)) return;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "description": "Native 64-bit integers with overflow protection.",
   "main": "lib/index.js",
   "scripts": {
+    "install": "prebuild-install || node-gyp rebuild",
     "install-debug": "node-gyp rebuild --debug",
-    "test": "$(npm bin)/mocha --bail --timeout 1000 --slow 500"
+    "test": "$(npm bin)/mocha --bail --timeout 1000 --slow 500",
+    "prebuild-electron": "prebuild -r electron -t 2.0.0 -t 3.0.0 -t 4.0.0 -t 5.0.0 -t 6.0.0 -t 7.0.0",
+    "prebuild": "prebuild -r node -t 8.0.0 -t 10.0.0 -t 12.0.0"
   },
   "repository": {
     "type": "git",
@@ -25,6 +28,10 @@
     "url": "https://github.com/JoshuaWise/integer/issues"
   },
   "homepage": "https://github.com/JoshuaWise/integer#readme",
+  "dependencies": {
+    "bindings": "1.5.0",
+    "prebuild-install": "5.3.2"
+  },
   "devDependencies": {
     "chai": "^4.1.2",
     "mocha": "^3.5.3"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/JoshuaWise/integer#readme",
   "dependencies": {
     "bindings": "1.5.0",
+    "prebuild": "^9.1.1",
     "prebuild-install": "5.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
* This adds prebuild support.  When the library is released from GitHub a travis build will run which builds the library for Node 8, 10 and 12, and Electron 2 - 7
* Modifies the binding.gyp file to remove the copy command for the .node file.  This is unnecessary and leaves the file in two spots.  The code now loads the .node file from either the Release or Debug directory in the build folder.

- Important: when this is pulled, you will need to update the deploy section of the .travis.yml file to have your github token encrypted and modify the repository so that Travis will automatically push the artifacts when you create a release in GitHub.  I run ```travis setup releases``` locally on my computer and then be sure to copy back in the ```  on:
    repo: JoshuaWise/better-sqlite3
    tags: true``` section to only build artifacts on release, and the ```file_glob: true
  skip_cleanup: true``` keys as well.